### PR TITLE
Remove unnecessary tab permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Here's [a blog post explaining it](https://60devs.com/hot-reloading-for-chrome-e
 2. Edit your `manifest.json` this way:
 
 ```json
-    "permissions": ["tabs", "activeTab"],
-    
     "background": { "scripts": ["hot-reload.js"] }
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,6 @@
     "description": "An example extension which demonstrates hot-reloading",
     "version":     "1.1337.0",
 
-    "permissions": ["tabs", "activeTab"],
-
     "background": {
         "scripts": ["hot-reload.js"]
     }


### PR DESCRIPTION
Search (`chrome.tabs.query`) and reload (`chrome.tabs.reload`) API can be used without `tabs` and `activeTabs` permissions.

> The majority of the chrome.tabs API can be used without declaring any permission. However, the "tabs" permission is required in order to populate the url, title, and favIconUrl properties of Tab. 


[chrome.tabs - Google Chrome](https://developer.chrome.com/extensions/tabs "https://developer.chrome.com/extensions/tabs")