### PR TITLE
Fixed "Extension reloaded itself too frequently"

### DIFF
--- a/hot-reload.js
+++ b/hot-reload.js
@@ -18,13 +18,7 @@ const timestampForFilesInDirectory = dir =>
             files.map (f => f.name + f.lastModifiedDate).join ())
 
 const reload = () => {
-
-    chrome.tabs.query ({ active: true, currentWindow: true }, tabs => {
-
-        if (tabs[0]) { chrome.tabs.reload (tabs[0].id) }
-
-        chrome.runtime.reload ()
-    })
+    chrome.developerPrivate.reload(chrome.runtime.id, {failQuietly: true});
 }
 
 const watchChanges = (dir, lastTimestamp) => {


### PR DESCRIPTION
"This extension reloaded itself too frequently." error which would stop crx-hotreload from working and the extension would have to be manually reloaded. See below:

https://stackoverflow.com/questions/29086691/chrome-this-extension-loaded-itself-too-frequently https://chromium.googlesource.com/chromium/src/+/e9d7496ee1703754c5d56027aa2758a09c473c0a

Replaced **chrome.runtime.reload()** with **chrome.developerPrivate.reload()**

Similar to how reloading works in extensions.js at chrome://extensions. See below:

```
// The 'Reload' link.
wrapper.setupColumn('localReload', '.reload-link', 'click', function(e) {
    chrome.developerPrivate.reload(extension.id, {failQuietly: true});
});
```