### PR TITLE
 Only change the default param

### DIFF
--- a/hot-reload.js
+++ b/hot-reload.js
@@ -19,7 +19,7 @@ const timestampForFilesInDirectory = dir =>
 
 const reload = () => {
 
-    chrome.tabs.query ({ active: true, currentWindow: true }, tabs => {
+    chrome.tabs.query ({ active: true, currentWindow: false }, tabs => {
 
         if (tabs[0]) { chrome.tabs.reload (tabs[0].id) }
 


### PR DESCRIPTION
Сhange default param to currentWindow: false.

it is probably more convenient to use from the beginning.
Because without this parameter the script rarely reloads the page, only when I managed to switch very quickly to the browser window. This can be confused