### PR TITLE
Set short timeout before reload following tab query as script content…

### DIFF
--- a/hot-reload.js
+++ b/hot-reload.js
@@ -22,8 +22,12 @@ const reload = () => {
     chrome.tabs.query ({ active: true, currentWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
 
         if (tabs[0]) { chrome.tabs.reload (tabs[0].id) }
+		{
+            setTimeout(function () {
 
-        chrome.runtime.reload ()
+                chrome.runtime.reload ()
+            }, 500)
+        }
     })
 }
 


### PR DESCRIPTION
Set short timeout before reload following tab query as script content sometimes does not render without. Following this change content rendering seems to be more reliable.