### PR TITLE
Use execute script to reload page rather than chrome.tabs.reload()

### DIFF
--- a/hot-reload.js
+++ b/hot-reload.js
@@ -21,13 +21,12 @@ const reload = () => {
 
     chrome.tabs.query ({ active: true, currentWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
 
-        if (tabs[0]) { chrome.tabs.reload (tabs[0].id) }
-		{
-            setTimeout(function () {
+        if (tabs[0]) { 
 
-                chrome.runtime.reload ()
-            }, 500)
+            chrome.tabs.executeScript(tabs[0].id, {code: 'setTimeout(function () { location.reload(); }, 300)'}, function() {});
         }
+
+        chrome.runtime.reload ()
     })
 }
 


### PR DESCRIPTION
This is a better fix to the previous PR.

Calling chrome.tabs.reload (tabs[0].id) is unreliable as the call to chrome.runtime.reload() kills the operation before it can complete. Executing location.reload() with a timeout in the tab page will complete however.

