### PR TITLE
Avoid error in Safari

### DIFF
--- a/hot-reload.js
+++ b/hot-reload.js
@@ -24,13 +24,16 @@ const watchChanges = (dir, lastTimestamp) => {
     })
 }
 
-chrome.management.getSelf (self => {
-    if (self.installType === 'development') {
-        chrome.runtime.getPackageDirectoryEntry (dir => watchChanges (dir))
-        chrome.tabs.query ({ active: true, lastFocusedWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
-            if (tabs[0]) {
-                chrome.tabs.reload (tabs[0].id)
-            }
-        })
-    }
-})
+// This is not supported in Safari
+if (chrome.management && chrome.management.getSelf) {
+    chrome.management.getSelf (self => {
+        if (self.installType === 'development') {
+            chrome.runtime.getPackageDirectoryEntry (dir => watchChanges (dir))
+            chrome.tabs.query ({ active: true, lastFocusedWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
+                if (tabs[0]) {
+                    chrome.tabs.reload (tabs[0].id)
+                }
+            })
+        }
+    })
+}


### PR DESCRIPTION
`chrome.management.getSelf` doesn't exist in Safari. This PR avoids calling it in that case.

People who are using the same codebase for both Chrome and Safari will run into this issue. The import can't be removed from the user's codebase because it's needed for Chrome. It's probably impossible for the import to be made a conditional dynamic import (although this depends on their build setup).